### PR TITLE
Allow to make snapshot of array

### DIFF
--- a/src/memorize.test.ts
+++ b/src/memorize.test.ts
@@ -170,6 +170,18 @@ test("works with undefined value", async () => {
   expect(data).toBeUndefined();
 });
 
+test("works with array value", async () => {
+  process.argv.push("--updateSnapshot");
+  process.env.SLAPSHOT_ONLINE = "true";
+
+  memorize("c", () => [1, 2, 3]);
+
+  process.argv = process.argv.filter(e => e !== "--updateSnapshot");
+  process.env.SLAPSHOT_ONLINE = "false";
+  const data = memorize("c", () => {});
+  expect(data).toEqual([1, 2, 3]);
+});
+
 test("nested APIs with functions throw an error when called unless mocked manualy", async () => {
   process.argv.push("--updateSnapshot");
   process.env.SLAPSHOT_ONLINE = "true";

--- a/src/safeSnapshot.ts
+++ b/src/safeSnapshot.ts
@@ -1,10 +1,15 @@
-export function safeSnapshot(obj: any, toSnapshot: boolean = true) {
+export function safeSnapshot(obj: any, toSnapshot: boolean = true): any {
   if (typeof obj !== "object") {
     return obj;
   }
   if (obj === null) {
     return null;
   }
+
+  if (Array.isArray(obj)) {
+    return obj.map((val: any) => safeSnapshot(val, toSnapshot));
+  }
+
   return Object.keys(obj).reduce(
     (safeObject, key) => {
       if (


### PR DESCRIPTION
Slapshot was not able to make snapshot of array it was serializing array as number indexed object
```
{
'0': 'value',
'1': 'value',
}
```